### PR TITLE
bug fix without using --version-by-branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Test using a branch to trigger deployments
 
-v1
+v2


### PR DESCRIPTION
This will publish 2.0.1 because we have not enabled --version-by-branch.